### PR TITLE
Set timeout on read/write socket operation

### DIFF
--- a/egctl.c
+++ b/egctl.c
@@ -344,6 +344,7 @@ Config get_device_conf(const char *name)
 
 int create_socket(const struct sockaddr_in *addr)
 {
+    struct timeval timeout;
     int ret;
     int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
@@ -354,6 +355,18 @@ int create_socket(const struct sockaddr_in *addr)
 
     if (ret != 0)
         fatal("Unable to connect: %s", strerror(errno));
+
+    timeout.tv_sec = 10;
+    timeout.tv_usec = 0;
+    ret = setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO,
+		    (char *)&timeout, sizeof(timeout));
+    if (ret != 0)
+        fatal("Unable to set socket options: %s", strerror(errno));
+
+    ret = setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO,
+		    (char *)&timeout, sizeof(timeout));
+    if (ret != 0)
+        fatal("Unable to set socket option: %s", strerror(errno));
 
     return sock;
 }


### PR DESCRIPTION
EG-PMS2-LAN sometimes does not response on read requests. In this
case egctl hangs on the read call until the TCP connection times
out. The default linger value is 15, which corresponds to a
duration of approximately between 13 to 30 minutes, depending on
the retransmission timeout.

If the EG-PMS2-LAN is used in an testing environment where a DUT
is automatically powered on and off many times, the hanger
blocks the test framework unnecessary. The test framework is able
to handle failed operations. Instead blocking so long only wait for
10 seconds and report an error if we don't got any response.