### PR TITLE
added short actions, single socket command and json output

### DIFF
--- a/egctl.c
+++ b/egctl.c
@@ -538,13 +538,11 @@ Actions argv_single_to_action(char *argv[])
         actions.socket[i] = ACTION_LEFT;
     }
     res = - strtoimax(argv[0], &err, 10);  /* returns 0 on invalid, -1...-4 on -1...-4 */
-    if ( res < 1 || res > SOCKET_COUNT ) {
+    if ( res < 1 || res > SOCKET_COUNT ) 
 	fatal("Invalid socket number %i", res);
-    }
     Action action = str_to_action(argv[1]);	 
-    if (action == ACTION_INVALID) {
+    if (action == ACTION_INVALID) 
         fatal("Invalid action for socket %zu: %s", res, argv[1]);
-    }
     actions.socket[ res - 1 ] = action;
 
     return actions;
@@ -636,6 +634,15 @@ void dump_status(Status st)
         printf("socket %zu - %s\n", i+1, get_state_str(st.socket[i]));
 }
 
+void dump_json(Status st)
+{
+    size_t i;
+    for (i = 0; i < SOCKET_COUNT; i++)
+        printf("%s%zu:\"%s\"", (i==0) ? "{ " : ", ", i+1, get_state_str(st.socket[i]));
+    printf(" }\n");
+}
+
+
 int main(int argc, char *argv[])
 {
     int sock;
@@ -664,7 +671,10 @@ int main(int argc, char *argv[])
         send_controls(sock, sess, ctrl);
     }
 
-    dump_status(recv_status(sock, sess, conf.proto));
+    Status st = recv_status(sock, sess, conf.proto);
+    dump_status(st);
+    printf("JSON=");
+    dump_json(st);
 
     close_session(sock);
     close(sock);

--- a/egctl.c
+++ b/egctl.c
@@ -537,7 +537,7 @@ Actions argv_single_to_action(char *argv[])
     for (i = 0; i < SOCKET_COUNT; i++) {
         actions.socket[i] = ACTION_LEFT;
     }
-    res = - strtoimax(argv[0], &err, 10);  /* returns 0 on invalid, -1...-4 on -1...-4 */
+    res = strtoimax(argv[0], &err, 10);  /* returns 0 on invalid */
     if ( res < 1 || res > SOCKET_COUNT ) 
 	fatal("Invalid socket number %i", res);
     Action action = str_to_action(argv[1]);	 
@@ -652,7 +652,7 @@ int main(int argc, char *argv[])
     if (argc != 2 && argc != 4 && argc != 6) {
         fatal("egctl 0.1: EnerGenie EG-PMS-LAN control utility\n\n"
               "Usage: egctl NAME [S1 S2 S3 S4]\n"
-	      "   or: egctl NAME -SOCK Sn\n"
+	      "   or: egctl NAME SOCK Sn\n"
               "  NAME is the name of the device in the egtab file\n"
 	      "  SOCK is a socket number in the 2ndvarint of the command\n"
               "  Sn is an action to perform on n-th socket: "


### PR DESCRIPTION
hi vitaly,

thanks for your work. for my use case, I needed some extra options and added them:

1. short actions 0 | 1 | = | + for off | on | hold | toggle
    `egctl NAME 0 0 1 +`
1. an option to switch only one socket without typing all the =
    `egctl NAME SOCKET ACTION` like
    `egctl NAME 2 1` to switch on socket 2 on device NAME
1. some very basic JSON output that allows processing of the dump result e. g. with `awk` 
    `egctl NAME | awk -F = '/JSON/ { print $2; }` 
    which gives you something like 
    `{ 1:"off", 2:"on", 3:"off", 4:"off" }`

I hope you like the additions - please feel free to merge.