### PR TITLE
Override prefix and destdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ ifdef DEBUG
 	CFLAGS += -g -DDEBUG
 endif
 
-DESTDIR =
-PREFIX = /usr/local
+DESTDIR ?=
+PREFIX ?= /usr/local
 
 bindir = $(PREFIX)/bin
 mandir = $(PREFIX)/share/man

--- a/README.md
+++ b/README.md
@@ -6,22 +6,27 @@ surge protector with LAN/WLAN interface. It uses native data exchange
 protocol of the device, not HTTP.
 
 
-INSTALLATION
+## Installation
 
-   make
-   make install
+    make
+    make install
 
+will install in /usr/local. To use another prefix:
 
-SUPPORTED DEVICES
+    PREFIX=/usr make install
+
+The Makefile also understands `DESTDIR`.
+
+## Supported devices
 
 Currently the following devices are supported:
-- EG-PMS-LAN
-- EG-PM2-LAN
-- EG-PMS2-LAN
-- EG-PMS-WLAN
+* EG-PMS-LAN
+* EG-PM2-LAN
+* EG-PMS2-LAN
+* EG-PMS-WLAN
 
 
-THANKS TO
+## Thanks to
 
 Mārtiņš Brīvnieks for testing with EG-PMS2-LAN.
 Philipp Kolmann for reporting about compatibility with EG-PM2-LAN.


### PR DESCRIPTION
I wanted to be able to override PREFIX, so Debian could remove the only patch they had for egctl. Then I found https://github.com/edeX-UG/egctl which already did the same and had IMO nice README improvements as well. So, I added overriding DESTDIR as well and now forward these patches. I hope you like them.