### PR TITLE
use _DEFAULT_SOURCE as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # See the included COPYING file.
 #
 
-CFLAGS = -W -Wall -D_BSD_SOURCE
+CFLAGS = -W -Wall -D_BSD_SOURCE -D_DEFAULT_SOURCE
 
 ifdef DEBUG
 	CFLAGS += -g -DDEBUG


### PR DESCRIPTION
Use both *_SOURCE as suggested here:

https://stackoverflow.com/questions/29201515/what-does-d-default-source-do

Fixes:

In file included from /usr/include/arpa/inet.h:21,
                 from egctl.c:10:
/usr/include/features.h:187:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
  187 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"